### PR TITLE
2.0.1

### DIFF
--- a/nodes/Ntfy/Ntfy.node.ts
+++ b/nodes/Ntfy/Ntfy.node.ts
@@ -26,7 +26,7 @@ export class Ntfy implements INodeType {
 			name: 'NTFY',
 		},
 		inputs: [NodeConnectionTypes.Main],
-		outputs: [],
+		outputs: [NodeConnectionTypes.Main],
 		properties: [...mainFields, ...additionalFields],
 		credentials: [
 			{

--- a/nodes/Ntfy/fields/mainFields.ts
+++ b/nodes/Ntfy/fields/mainFields.ts
@@ -84,5 +84,7 @@ export const mainFields: INodeProperties[] = [
 			rows: 7,
 		},
 		default: '',
+		description:
+			'Rich-text (line breaks, emojis, etc.) is supported as long as the "Attachment by File" field is not present in "Additional Options"',
 	},
 ];

--- a/nodes/Ntfy/genericFunctions.ts
+++ b/nodes/Ntfy/genericFunctions.ts
@@ -10,7 +10,7 @@ import type { Readable } from 'stream';
 
 type NTFYRequestData = {
 	headers: { [key: string]: string };
-	body?: Buffer<ArrayBufferLike> | Readable;
+	body?: Buffer<ArrayBufferLike> | Readable | string;
 };
 
 type EmojisAndTags = {
@@ -38,6 +38,18 @@ type N8NAttachment = {
 		url: string;
 	};
 };
+
+type AdditionalOptions =
+	| {
+			actions?: object;
+			fileAttach?: string;
+			urlAttach?: string;
+			click?: string;
+			icon?: string;
+			markdown?: boolean;
+			delay?: string;
+	  }
+	| undefined;
 
 function getFieldsFromNode(this: IExecuteFunctions) {
 	const nodeParameters = this.getNode().parameters;
@@ -113,6 +125,20 @@ function setHeaderName(field: string) {
 	);
 }
 
+function isValidHttpHeader(str: string) {
+	for (const char of str) {
+		const charCode = char.codePointAt(0)!;
+
+		// Allow tabs
+		if (charCode === 0x09) continue;
+		// Allow printable ASCII
+		if (charCode >= 0x20 && charCode <= 0x7e) continue;
+
+		return false;
+	}
+	return true;
+}
+
 export async function constructRequestData(
 	this: IExecuteFunctions,
 	index: number,
@@ -129,6 +155,17 @@ export async function constructRequestData(
 		if (!value) continue;
 
 		switch (field) {
+			case 'message':
+				if (
+					isValidHttpHeader(value as string) &&
+					(getValueFromNodeParameter.call(this, index, 'additionalOptions') as AdditionalOptions)
+						?.fileAttach
+				) {
+					requestData.headers['X-Message'] = value as string;
+				} else {
+					requestData.body = value as string;
+				}
+				break;
 			case 'tags':
 				if ((value as EmojisAndTags).emojis || (value as EmojisAndTags).customTags) {
 					requestData.headers[fieldHeaderName] = getTagsFromNodeParameter.call(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@jyln/n8n-nodes-ntfy",
-	"version": "1.2.0",
+	"version": "2.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@jyln/n8n-nodes-ntfy",
-			"version": "1.2.0",
+			"version": "2.0.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@n8n/node-cli": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jyln/n8n-nodes-ntfy",
-	"version": "1.2.0",
+	"version": "2.0.0",
 	"description": "A community n8n node for ntfy.sh",
 	"license": "MIT",
 	"homepage": "https://github.com/JYLN/n8n-nodes-ntfy.git",


### PR DESCRIPTION
Addresses 2 notable bugs since the 2.0.0 release. Resolves #25, resolves #27.

A big note about this release is that the `Message` field's backend operation has been updated so that if the value of the field is a valid HTTP Header string and the "Attachment by File" field is used, the message will be placed in the headers instead. Otherwise, the message is put in the body so that any rich-text or other formatting can be processed.