### PR TITLE
2.0.2

### DIFF
--- a/nodes/Ntfy/genericFunctions.ts
+++ b/nodes/Ntfy/genericFunctions.ts
@@ -125,28 +125,66 @@ function setHeaderName(field: string) {
 	);
 }
 
-function isValidHttpHeader(str: string) {
-	for (const char of str) {
-		const charCode = char.codePointAt(0)!;
+function isValidHttpHeaderValue(val: unknown): val is string {
+	if (typeof val !== 'string') return false;
 
-		// Allow tabs
-		if (charCode === 0x09) continue;
-		// Allow printable ASCII
-		if (charCode >= 0x20 && charCode <= 0x7e) continue;
+	for (const char of val) {
+		const codePoint = char.codePointAt(0)!;
 
-		return false;
+		// Reject C0 control chars, including CR, LF, Tab...
+		if (codePoint < 0x20) return false;
+
+		// Reject DEL
+		if (codePoint === 0x7f) return false;
+
+		// Reject C1 control chars
+		if (codePoint >= 0x80 && codePoint <= 0x9f) return false;
 	}
+
 	return true;
 }
 
-function encodeHeaders(val: unknown): string {
-	const string = String(val);
-
-	if (/^[\x00-\x7f]*$/.test(string)) {
-		return string;
+function validateHeaderValue(this: IExecuteFunctions, val: unknown, headerName: string): string {
+	if (typeof val !== 'string' && typeof val !== 'number' && typeof val !== 'boolean') {
+		throw new NodeOperationError(
+			this.getNode(),
+			`Header "${headerName}" must be a string, number, or boolean`,
+		);
 	}
 
-	return `=?UTF-8?B?${Buffer.from(string, 'utf-8').toString('base64')}?=`;
+	const stringValue = String(val);
+
+	if (!isValidHttpHeaderValue(stringValue)) {
+		throw new NodeOperationError(
+			this.getNode(),
+			`Header "${headerName}" contains invalid control characters`,
+		);
+	}
+
+	return stringValue;
+}
+
+function encodeRfc2047(val: string): string {
+	return `=?UTF-8?B?${Buffer.from(val, 'utf-8').toString('base64')}?=`;
+}
+
+function encodeHeaderValue(this: IExecuteFunctions, val: unknown, headerName: string): string {
+	if (headerName.toLowerCase() === 'x-message') {
+		if (typeof val !== 'string') {
+			throw new NodeOperationError(this.getNode(), `Header ${headerName} must be a string`);
+		}
+
+		return encodeRfc2047(val);
+	}
+
+	const stringValue = validateHeaderValue.call(this, val, headerName);
+	for (const char of stringValue) {
+		if (char.codePointAt(0)! > 0x7f) {
+			return encodeRfc2047(stringValue);
+		}
+	}
+
+	return stringValue;
 }
 
 export async function constructRequestData(
@@ -162,31 +200,42 @@ export async function constructRequestData(
 		const fieldHeaderName = setHeaderName(field);
 		const value = getValueFromNodeParameter.call(this, index, field);
 
-		if (!value) continue;
+		if (value === null || value === undefined) continue;
 
 		switch (field) {
-			case 'message':
-				if (
-					isValidHttpHeader(value as string) &&
-					(getValueFromNodeParameter.call(this, index, 'additionalOptions') as AdditionalOptions)
-						?.fileAttach
-				) {
-					requestData.headers['X-Message'] = value as string;
+			case 'message': {
+				const additionalOptions = getValueFromNodeParameter.call(
+					this,
+					index,
+					'additionalOptions',
+				) as AdditionalOptions;
+
+				const message = String(value);
+
+				if (additionalOptions?.fileAttach) {
+					requestData.headers['X-Message'] = message;
 				} else {
-					requestData.body = value as string;
+					requestData.body = message;
 				}
 				break;
-			case 'tags':
-				if ((value as EmojisAndTags).emojis || (value as EmojisAndTags).customTags) {
-					requestData.headers[fieldHeaderName] = getTagsFromNodeParameter.call(
+			}
+			case 'tags': {
+				const tags = value as EmojisAndTags;
+
+				if (tags.emojis || tags.customTags) {
+					const tagValue = getTagsFromNodeParameter.call(this, tags);
+
+					requestData.headers[fieldHeaderName] = validateHeaderValue.call(
 						this,
-						value as EmojisAndTags,
+						tagValue,
+						fieldHeaderName,
 					);
 				}
 				break;
+			}
 			case 'additionalOptions': {
 				const additionalFields = value;
-				const returnHeaders = {} as NTFYRequestData['headers'];
+				const returnHeaders: NTFYRequestData['headers'] = {};
 				for (const [additionalField, additionalValue] of Object.entries(additionalFields)) {
 					if (additionalField === 'actions') {
 						returnHeaders['X-Actions'] = getActionButtonsFromNodeParameter(
@@ -214,14 +263,20 @@ export async function constructRequestData(
 						}
 						continue;
 					}
-					returnHeaders[setHeaderName(additionalField)] = additionalValue;
+
+					const headerName = setHeaderName(additionalField);
+					returnHeaders[headerName] = validateHeaderValue.call(this, additionalValue, headerName);
 				}
 
 				Object.assign(requestData.headers, returnHeaders);
 				break;
 			}
 			default:
-				requestData.headers[fieldHeaderName] = value as string;
+				requestData.headers[fieldHeaderName] = validateHeaderValue.call(
+					this,
+					value,
+					fieldHeaderName,
+				);
 		}
 	}
 
@@ -240,7 +295,7 @@ export async function requestNTFYApi(
 
 		const requestHeaders: { [key: string]: string } = {};
 		for (const [header, value] of Object.entries(restHeaders)) {
-			requestHeaders[header] = encodeHeaders(value);
+			requestHeaders[header] = encodeHeaderValue.call(this, value, header);
 		}
 
 		const options: IHttpRequestOptions = {

--- a/nodes/Ntfy/genericFunctions.ts
+++ b/nodes/Ntfy/genericFunctions.ts
@@ -139,6 +139,16 @@ function isValidHttpHeader(str: string) {
 	return true;
 }
 
+function encodeHeaders(val: unknown): string {
+	const string = String(val);
+
+	if (/^[\x00-\x7f]*$/.test(string)) {
+		return string;
+	}
+
+	return `=?UTF-8?B?${Buffer.from(string, 'utf-8').toString('base64')}?=`;
+}
+
 export async function constructRequestData(
 	this: IExecuteFunctions,
 	index: number,
@@ -228,10 +238,15 @@ export async function requestNTFYApi(
 		const serverUrl = credentials.serverUrl as string;
 		const { 'X-Topic': topic, ...restHeaders } = requestData.headers;
 
+		const requestHeaders: { [key: string]: string } = {};
+		for (const [header, value] of Object.entries(restHeaders)) {
+			requestHeaders[header] = encodeHeaders(value);
+		}
+
 		const options: IHttpRequestOptions = {
 			method: 'POST',
 			url: serverUrl + '/' + topic,
-			headers: restHeaders,
+			headers: requestHeaders,
 			body: requestData.body || undefined,
 		};
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
 	"name": "@jyln/n8n-nodes-ntfy",
-	"version": "2.0.0",
+	"version": "2.0.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@jyln/n8n-nodes-ntfy",
-			"version": "2.0.0",
+			"version": "2.0.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@n8n/node-cli": "*",
 				"@types/node": "^25.0.10",
-				"eslint": "9.32.0",
-				"prettier": "3.6.2",
-				"release-it": "^19.0.4",
-				"typescript": "5.9.2"
+				"eslint": "9.39.4",
+				"prettier": "3.8.3",
+				"release-it": "20.2.0",
+				"typescript": "5.9.3"
 			},
 			"peerDependencies": {
 				"n8n-workflow": "*"
@@ -107,24 +107,24 @@
 			}
 		},
 		"node_modules/@eslint/config-array": {
-			"version": "0.21.1",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-			"integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+			"version": "0.21.2",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+			"integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@eslint/object-schema": "^2.1.7",
 				"debug": "^4.3.1",
-				"minimatch": "^3.1.2"
+				"minimatch": "^3.1.5"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -133,9 +133,9 @@
 			}
 		},
 		"node_modules/@eslint/config-array/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -146,19 +146,22 @@
 			}
 		},
 		"node_modules/@eslint/config-helpers": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
-			"integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+			"integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^0.17.0"
+			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/@eslint/core": {
-			"version": "0.15.2",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
-			"integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+			"integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -169,20 +172,20 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
-			"integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
+			"version": "3.3.7",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.7.tgz",
+			"integrity": "sha512-F42g89Qd5oAWtp0k0nnSrjziAKza7w8SVT4mStc18LZMaRb4J1HQAHLCalEtDCxrTuksx7NU9qsmeLwpOfPqWw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ajv": "^6.12.4",
+				"ajv": "^6.14.0",
 				"debug": "^4.3.2",
 				"espree": "^10.0.1",
 				"globals": "^14.0.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
-				"js-yaml": "^4.1.1",
-				"minimatch": "^3.1.2",
+				"js-yaml": "^4.3.2",
+				"minimatch": "^3.1.5",
 				"strip-json-comments": "^3.1.1"
 			},
 			"engines": {
@@ -193,9 +196,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -204,9 +207,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -217,9 +220,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.32.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.32.0.tgz",
-			"integrity": "sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==",
+			"version": "9.39.4",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+			"integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -240,13 +243,13 @@
 			}
 		},
 		"node_modules/@eslint/plugin-kit": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
-			"integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+			"integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^0.15.2",
+				"@eslint/core": "^0.17.0",
 				"levn": "^0.4.1"
 			},
 			"engines": {
@@ -284,6 +287,7 @@
 			"deprecated": "Use @eslint/config-array instead",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@humanwhocodes/object-schema": "^2.0.3",
 				"debug": "^4.3.1",
@@ -299,6 +303,7 @@
 			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -310,6 +315,7 @@
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -337,7 +343,8 @@
 			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
 			"deprecated": "Use @eslint/object-schema instead",
 			"dev": true,
-			"license": "BSD-3-Clause"
+			"license": "BSD-3-Clause",
+			"peer": true
 		},
 		"node_modules/@humanwhocodes/retry": {
 			"version": "0.4.3",
@@ -354,30 +361,29 @@
 			}
 		},
 		"node_modules/@inquirer/ansi": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
-			"integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.8.tgz",
+			"integrity": "sha512-WpQM+Ti6Z40EFwwt+uL2p4UabT+W179zHp6HhLVOzfbwnVn05IPO/eXIZXGNqcT1jbQ15SujNLzQ39k4QPPxBQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			}
 		},
 		"node_modules/@inquirer/checkbox": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
-			"integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+			"version": "5.2.5",
+			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.5.tgz",
+			"integrity": "sha512-bRt8J8m+Fot9CXv+zNQGXUq2ET0MggR1fPz7v6edN6MFYmsbfGnMmkmWZJEegMKqrAC8ej/o1sqisHZXZJMAfQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/ansi": "^1.0.2",
-				"@inquirer/core": "^10.3.2",
-				"@inquirer/figures": "^1.0.15",
-				"@inquirer/type": "^3.0.10",
-				"yoctocolors-cjs": "^2.1.3"
+				"@inquirer/ansi": "^2.0.8",
+				"@inquirer/core": "^12.0.3",
+				"@inquirer/figures": "^2.0.9",
+				"@inquirer/type": "4.1.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -389,17 +395,17 @@
 			}
 		},
 		"node_modules/@inquirer/confirm": {
-			"version": "5.1.21",
-			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
-			"integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+			"version": "6.3.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.2.tgz",
+			"integrity": "sha512-Xvr/0HggjddPtGppuqVmxhTw+Hr8PvsZ/k0HmOEaAqQEt80OITNkFWnsdNmyT0/eM4Ab+iJLx2R8rctlEyfSVg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.3.2",
-				"@inquirer/type": "^3.0.10"
+				"@inquirer/core": "^12.0.3",
+				"@inquirer/type": "4.1.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -411,23 +417,22 @@
 			}
 		},
 		"node_modules/@inquirer/core": {
-			"version": "10.3.2",
-			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
-			"integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+			"version": "12.0.3",
+			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.3.tgz",
+			"integrity": "sha512-wsSy0sznmXwkty+2PzZwx00Cazc/E0r0B7mAzdGROz2Ct+DFZXaK7WDjGZvgjRldxH5ZhFVfF2lgkYrqgOw2KA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/ansi": "^1.0.2",
-				"@inquirer/figures": "^1.0.15",
-				"@inquirer/type": "^3.0.10",
+				"@inquirer/ansi": "^2.0.8",
+				"@inquirer/figures": "^2.0.9",
+				"@inquirer/type": "4.1.1",
 				"cli-width": "^4.1.0",
-				"mute-stream": "^2.0.0",
-				"signal-exit": "^4.1.0",
-				"wrap-ansi": "^6.2.0",
-				"yoctocolors-cjs": "^2.1.3"
+				"fast-wrap-ansi": "^0.2.0",
+				"mute-stream": "^3.0.0",
+				"signal-exit": "^4.1.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -438,57 +443,19 @@
 				}
 			}
 		},
-		"node_modules/@inquirer/core/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@inquirer/core/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@inquirer/core/node_modules/wrap-ansi": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/@inquirer/editor": {
-			"version": "4.2.23",
-			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
-			"integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.3.tgz",
+			"integrity": "sha512-YsKkS2q63IiLtaDK/9nqzdComN97SDQrmKiyNggN+ceP4ty+Z6VwyTz3FpjeUWeW1Efss2xHFKCC9sx7hnrsxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.3.2",
-				"@inquirer/external-editor": "^1.0.3",
-				"@inquirer/type": "^3.0.10"
+				"@inquirer/core": "^12.0.3",
+				"@inquirer/external-editor": "^3.0.5",
+				"@inquirer/type": "4.1.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -500,18 +467,17 @@
 			}
 		},
 		"node_modules/@inquirer/expand": {
-			"version": "4.0.23",
-			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
-			"integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.5.tgz",
+			"integrity": "sha512-uHuXLmXW+TtIfT/9vSBotypAkqn1n34Ul+CLGPos/xANyO4Ff5xZzkYhbKR4NEcfVK4a9mHQOpwVZzluSHFRGw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.3.2",
-				"@inquirer/type": "^3.0.10",
-				"yoctocolors-cjs": "^2.1.3"
+				"@inquirer/core": "^12.0.3",
+				"@inquirer/type": "4.1.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -523,17 +489,17 @@
 			}
 		},
 		"node_modules/@inquirer/external-editor": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
-			"integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.5.tgz",
+			"integrity": "sha512-f3QQJRIX5ZEneBHNUIuPjmbdzHnmRFJA8r2dkcb8q+OM5Uv5KtnuAttQumnrjcBVBM3mcTX1CkmtAkU58VRZxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"chardet": "^2.1.1",
-				"iconv-lite": "^0.7.0"
+				"iconv-lite": "^0.7.2"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -545,27 +511,27 @@
 			}
 		},
 		"node_modules/@inquirer/figures": {
-			"version": "1.0.15",
-			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
-			"integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.9.tgz",
+			"integrity": "sha512-EAWgUTGQ/Umgga51dE3B2PUHbufuXarDfg86uVgoSgNHNNQnyFKcOrQLWVqYMghuSyHh8+2HUH0Js9cTC1WAdg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			}
 		},
 		"node_modules/@inquirer/input": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
-			"integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.6.tgz",
+			"integrity": "sha512-HtcJhB2QFVXbLuJ5S3syhNbTUVxYvwqV4VRBDkQceBloC9bmTViUoRFP5PbSaDZb3HzfPmpuU/gG4ybVBz4FHA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.3.2",
-				"@inquirer/type": "^3.0.10"
+				"@inquirer/core": "^12.0.3",
+				"@inquirer/type": "4.1.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -577,17 +543,17 @@
 			}
 		},
 		"node_modules/@inquirer/number": {
-			"version": "3.0.23",
-			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
-			"integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.3.tgz",
+			"integrity": "sha512-6Yuwh1NGSbu1Lo4N1EWjXs1jKRntLg/ZCwhmeorEHde90v1XxAozdbd4Iu30eOQLW+6h1hp2O9ujNfLSbTPJnA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.3.2",
-				"@inquirer/type": "^3.0.10"
+				"@inquirer/core": "^12.0.3",
+				"@inquirer/type": "4.1.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -599,18 +565,18 @@
 			}
 		},
 		"node_modules/@inquirer/password": {
-			"version": "4.0.23",
-			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
-			"integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.2.tgz",
+			"integrity": "sha512-W9zYdyzogK+6110mqwaSJWCBu2yA5Q/OfnGSjjZB1bNpHlmUozXxTl0+QOZBNeVd6Qo81/qT75gW05gLAtITxw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/ansi": "^1.0.2",
-				"@inquirer/core": "^10.3.2",
-				"@inquirer/type": "^3.0.10"
+				"@inquirer/ansi": "^2.0.8",
+				"@inquirer/core": "^12.0.3",
+				"@inquirer/type": "4.1.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -622,25 +588,25 @@
 			}
 		},
 		"node_modules/@inquirer/prompts": {
-			"version": "7.10.1",
-			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
-			"integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.4.2.tgz",
+			"integrity": "sha512-XJmn/wY4AX56l1BRU+ZjDrFtg9+2uBEi4JvJQj82kwJDQKiPgSn4CEsbfGGygS4Gw6rkL4W18oATjfVfaqub2Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/checkbox": "^4.3.2",
-				"@inquirer/confirm": "^5.1.21",
-				"@inquirer/editor": "^4.2.23",
-				"@inquirer/expand": "^4.0.23",
-				"@inquirer/input": "^4.3.1",
-				"@inquirer/number": "^3.0.23",
-				"@inquirer/password": "^4.0.23",
-				"@inquirer/rawlist": "^4.1.11",
-				"@inquirer/search": "^3.2.2",
-				"@inquirer/select": "^4.4.2"
+				"@inquirer/checkbox": "^5.1.4",
+				"@inquirer/confirm": "^6.0.12",
+				"@inquirer/editor": "^5.1.1",
+				"@inquirer/expand": "^5.0.13",
+				"@inquirer/input": "^5.0.12",
+				"@inquirer/number": "^4.0.12",
+				"@inquirer/password": "^5.0.12",
+				"@inquirer/rawlist": "^5.2.8",
+				"@inquirer/search": "^4.1.8",
+				"@inquirer/select": "^5.1.4"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -652,18 +618,17 @@
 			}
 		},
 		"node_modules/@inquirer/rawlist": {
-			"version": "4.1.11",
-			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
-			"integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+			"version": "5.3.5",
+			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.5.tgz",
+			"integrity": "sha512-1oHky1ONfCOwNrnkQGDE1oaSij/3fI6HFMSf2H/WsGO2lEyDX9My82iggITSy9ddSZ8yk8j9v41OI0fVoSIoaA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.3.2",
-				"@inquirer/type": "^3.0.10",
-				"yoctocolors-cjs": "^2.1.3"
+				"@inquirer/core": "^12.0.3",
+				"@inquirer/type": "4.1.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -675,19 +640,18 @@
 			}
 		},
 		"node_modules/@inquirer/search": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
-			"integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.3.tgz",
+			"integrity": "sha512-fyuIU1Nbpvwlikjg3gXwJFDI11+EFjqQ7P+iByfmivIKQ1vmaykNrD/vy5unHuUqUpsOsnvJ25//tPF7E/RBRA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.3.2",
-				"@inquirer/figures": "^1.0.15",
-				"@inquirer/type": "^3.0.10",
-				"yoctocolors-cjs": "^2.1.3"
+				"@inquirer/core": "^12.0.3",
+				"@inquirer/figures": "^2.0.9",
+				"@inquirer/type": "4.1.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -699,20 +663,19 @@
 			}
 		},
 		"node_modules/@inquirer/select": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
-			"integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+			"version": "5.2.5",
+			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.5.tgz",
+			"integrity": "sha512-9kc15hr8r/kI+3DO/xLog5nOzTz1jqsHXa6JBFzmQKhkoJ8Slda1I1L/uD8ZSZ9tF1yp79wwXe7mclvX1rqR2Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/ansi": "^1.0.2",
-				"@inquirer/core": "^10.3.2",
-				"@inquirer/figures": "^1.0.15",
-				"@inquirer/type": "^3.0.10",
-				"yoctocolors-cjs": "^2.1.3"
+				"@inquirer/ansi": "^2.0.8",
+				"@inquirer/core": "^12.0.3",
+				"@inquirer/figures": "^2.0.9",
+				"@inquirer/type": "4.1.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -724,13 +687,13 @@
 			}
 		},
 		"node_modules/@inquirer/type": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
-			"integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.1.tgz",
+			"integrity": "sha512-yJoHYrMnxIsJZCY+0Vb66Dy3he3kL3e2wOBKhoSwWWAzZAY82emlxwgprCtp6yRixvNRNq9ztfRWQYPNr3Go7A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -843,6 +806,7 @@
 			"resolved": "https://registry.npmjs.org/@n8n_io/riot-tmpl/-/riot-tmpl-4.0.1.tgz",
 			"integrity": "sha512-/zdRbEfTFjsm1NqnpPQHgZTkTdbp5v3VUxGeMA9098sps8jRCTraQkc3AQstJgHUm7ylBXJcIVhnVeLUMWAfwQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"eslint-config-riot": "^1.0.0"
 			}
@@ -852,6 +816,7 @@
 			"resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.5.0.tgz",
 			"integrity": "sha512-0Vk1Eb3Uor+zeF/WVnuhFgJc51wEBTZNBlVQy3mvyr3sGmW86bP1jA7wmRsd0DZbswPwN0vNOl/TmkDTEopOtQ==",
 			"license": "SEE LICENSE IN LICENSE.md",
+			"peer": true,
 			"dependencies": {
 				"callsites": "3.1.0"
 			}
@@ -900,11 +865,28 @@
 				"eslint": ">= 9"
 			}
 		},
+		"node_modules/@n8n/node-cli/node_modules/prettier": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"prettier": "bin/prettier.cjs"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
+			}
+		},
 		"node_modules/@n8n/tournament": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.0.6.tgz",
 			"integrity": "sha512-UGSxYXXVuOX0yL6HTLBStKYwLIa0+JmRKiSZSCMcM2s2Wax984KWT6XIA1TR/27i7yYpDk1MY14KsTPnuEp27A==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@n8n_io/riot-tmpl": "^4.0.1",
 				"ast-types": "^0.16.1",
@@ -967,16 +949,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/@nodeutils/defaults-deep": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@nodeutils/defaults-deep/-/defaults-deep-1.1.0.tgz",
-			"integrity": "sha512-gG44cwQovaOFdSR02jR9IhVRpnDP64VN6JdjYJTfNz4J4fWn7TQnmrf22nSjRqlwlxPcW8PL/L3KbJg3tdwvpg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"lodash": "^4.15.0"
-			}
-		},
 		"node_modules/@oclif/core": {
 			"version": "4.8.0",
 			"resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.8.0.tgz",
@@ -1023,7 +995,6 @@
 			"integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^6.0.0",
 				"@octokit/graphql": "^9.0.3",
@@ -1188,13 +1159,6 @@
 				"url": "https://github.com/phun-ky/typeof?sponsor=1"
 			}
 		},
-		"node_modules/@tootallnate/quickjs-emscripten": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-			"integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@ts-morph/common": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.27.0.tgz",
@@ -1284,7 +1248,6 @@
 			"integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.16.0"
 			}
@@ -1348,7 +1311,6 @@
 			"integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.53.1",
 				"@typescript-eslint/types": "8.53.1",
@@ -1552,7 +1514,8 @@
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
 			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
 			"dev": true,
-			"license": "ISC"
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-android-arm-eabi": {
 			"version": "1.11.1",
@@ -1829,7 +1792,6 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1848,9 +1810,9 @@
 			}
 		},
 		"node_modules/agent-base": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-8.0.0.tgz",
+			"integrity": "sha512-QT8i0hCz6C/KQ+KTAbSNwCHDGdmUJl2tp2ZpNlGSWCfhUNVbYG2WLE3MdZGBAgXPV4GAvjGMxo+C1hroyxmZEg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1858,9 +1820,9 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1950,6 +1912,7 @@
 			"resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
 			"integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"is-nan": "^1.3.2",
@@ -1963,6 +1926,7 @@
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
 			"integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.0.1"
 			},
@@ -1991,13 +1955,15 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/available-typed-arrays": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
 			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"possible-typed-array-names": "^1.0.0"
 			},
@@ -2016,9 +1982,9 @@
 			"license": "MIT"
 		},
 		"node_modules/basic-ftp": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.1.0.tgz",
-			"integrity": "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+			"integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2105,6 +2071,7 @@
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
 			"integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.0",
 				"es-define-property": "^1.0.0",
@@ -2123,6 +2090,7 @@
 			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
 			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"es-errors": "^1.3.0",
 				"function-bind": "^1.1.2"
@@ -2136,6 +2104,7 @@
 			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
 			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
 				"get-intrinsic": "^1.3.0"
@@ -2205,9 +2174,9 @@
 			"license": "MIT"
 		},
 		"node_modules/chardet": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
-			"integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+			"integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2216,6 +2185,7 @@
 			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
 			"integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"engines": {
 				"node": "*"
 			}
@@ -2237,9 +2207,9 @@
 			}
 		},
 		"node_modules/ci-info": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
-			"integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
 			"dev": true,
 			"funding": [
 				{
@@ -2322,6 +2292,7 @@
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
 			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.1",
@@ -2336,6 +2307,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2345,6 +2317,7 @@
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -2382,6 +2355,7 @@
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"delayed-stream": "~1.0.0"
 			},
@@ -2443,14 +2417,15 @@
 			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
 			"integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/data-uri-to-buffer": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-			"integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-7.0.0.tgz",
+			"integrity": "sha512-CuRUx0TXGSbbWdEci3VK/XOZGP3n0P4pIKpsqpVtBqaIIuj3GKK8H45oAqA4Rg8FHipc+CzRdUzmD4YQXxv66Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2483,9 +2458,9 @@
 			"license": "MIT"
 		},
 		"node_modules/default-browser": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.4.0.tgz",
-			"integrity": "sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg==",
+			"version": "5.5.1",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+			"integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2517,6 +2492,7 @@
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
 			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"es-define-property": "^1.0.0",
 				"es-errors": "^1.3.0",
@@ -2547,6 +2523,7 @@
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
 			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"define-data-property": "^1.0.1",
 				"has-property-descriptors": "^1.0.0",
@@ -2560,16 +2537,16 @@
 			}
 		},
 		"node_modules/defu": {
-			"version": "6.1.4",
-			"resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-			"integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+			"version": "6.1.7",
+			"resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+			"integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/degenerator": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
-			"integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-6.0.0.tgz",
+			"integrity": "sha512-j5MdXdefrecJeSqTpUrgZd4fBsD2IxZx0JlJD+n1Q7+aTf7/HcyXSfHsicPW6ekPurX159v1ZYla6OJgSPh2Dw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2579,6 +2556,9 @@
 			},
 			"engines": {
 				"node": ">= 14"
+			},
+			"peerDependencies": {
+				"quickjs-wasi": "^0.0.1"
 			}
 		},
 		"node_modules/degenerator/node_modules/ast-types": {
@@ -2599,6 +2579,7 @@
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.4.0"
 			}
@@ -2629,6 +2610,7 @@
 			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"esutils": "^2.0.2"
 			},
@@ -2654,6 +2636,7 @@
 			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
 			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.1",
 				"es-errors": "^1.3.0",
@@ -2697,6 +2680,7 @@
 			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
 			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -2706,6 +2690,7 @@
 			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
 			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -2715,6 +2700,7 @@
 			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
 			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"es-errors": "^1.3.0"
 			},
@@ -2727,6 +2713,7 @@
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
 			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -2767,26 +2754,26 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.32.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.32.0.tgz",
-			"integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
+			"version": "9.39.4",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+			"integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.2.0",
+				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
-				"@eslint/config-array": "^0.21.0",
-				"@eslint/config-helpers": "^0.3.0",
-				"@eslint/core": "^0.15.0",
-				"@eslint/eslintrc": "^3.3.1",
-				"@eslint/js": "9.32.0",
-				"@eslint/plugin-kit": "^0.3.4",
+				"@eslint/config-array": "^0.21.2",
+				"@eslint/config-helpers": "^0.4.2",
+				"@eslint/core": "^0.17.0",
+				"@eslint/eslintrc": "^3.3.5",
+				"@eslint/js": "9.39.4",
+				"@eslint/plugin-kit": "^0.4.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
 				"@types/estree": "^1.0.6",
-				"@types/json-schema": "^7.0.15",
-				"ajv": "^6.12.4",
+				"ajv": "^6.14.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.6",
 				"debug": "^4.3.2",
@@ -2805,7 +2792,7 @@
 				"is-glob": "^4.0.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"lodash.merge": "^4.6.2",
-				"minimatch": "^3.1.2",
+				"minimatch": "^3.1.5",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.3"
 			},
@@ -2831,7 +2818,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-riot/-/eslint-config-riot-1.0.0.tgz",
 			"integrity": "sha512-NB/L/1Y30qyJcG5xZxCJKW/+bqyj+llbcCwo9DEz8bESIP0SLTOQ8T1DWCCFc+wJ61AMEstj4511PSScqMMfCw==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/eslint-import-context": {
 			"version": "0.1.9",
@@ -2899,7 +2887,6 @@
 			"integrity": "sha512-vPZZsiOKaBAIATpFE2uMI4w5IRwdv/FpQ+qZZMR4E+PeOcM4OeoEbqxRMnywdxP19TyB/3h6QBB0EWon7letSQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/types": "^8.35.0",
 				"comment-parser": "^1.4.1",
@@ -2966,6 +2953,7 @@
 			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
@@ -2990,6 +2978,7 @@
 			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -3001,6 +2990,7 @@
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -3014,6 +3004,7 @@
 			"integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
@@ -3129,6 +3120,7 @@
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -3140,6 +3132,7 @@
 			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
@@ -3196,6 +3189,7 @@
 			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
@@ -3213,6 +3207,7 @@
 			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -3224,6 +3219,7 @@
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -3237,6 +3233,7 @@
 			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"acorn": "^8.9.0",
 				"acorn-jsx": "^5.3.2",
@@ -3255,6 +3252,7 @@
 			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"flat-cache": "^3.0.4"
 			},
@@ -3268,6 +3266,7 @@
 			"integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"flatted": "^3.2.9",
 				"keyv": "^4.5.3",
@@ -3284,6 +3283,7 @@
 			"deprecated": "Glob versions prior to v9 are no longer supported",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -3305,6 +3305,7 @@
 			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -3316,6 +3317,7 @@
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -3329,6 +3331,7 @@
 			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"type-fest": "^0.20.2"
 			},
@@ -3362,6 +3365,7 @@
 			"deprecated": "Rimraf versions prior to v4 are no longer supported",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -3378,6 +3382,7 @@
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -3404,6 +3409,7 @@
 			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true,
 			"license": "(MIT OR CC0-1.0)",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -3442,9 +3448,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3466,9 +3472,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3527,6 +3533,7 @@
 			"resolved": "https://registry.npmjs.org/esprima-next/-/esprima-next-5.8.4.tgz",
 			"integrity": "sha512-8nYVZ4ioIH4Msjb/XmhnBdz5WRRBaYqevKa1cv9nGJdCehMbzZCPNEEnqfLCZVetUVrUPEcb5IYyu1GG4hFqgg==",
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"bin": {
 				"esparse": "bin/esparse.js",
 				"esvalidate": "bin/esvalidate.js"
@@ -3582,9 +3589,9 @@
 			}
 		},
 		"node_modules/eta": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/eta/-/eta-4.5.0.tgz",
-			"integrity": "sha512-qifAYjuW5AM1eEEIsFnOwB+TGqu6ynU3OKj9WbUTOtUBHFPZqL03XUW34kbp3zm19Ald+U8dEyRXaVsUck+Y1g==",
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/eta/-/eta-4.5.1.tgz",
+			"integrity": "sha512-EaNCGm+8XEIU7YNcc+THptWAO5NfKBHHARxt+wxZljj9bTr/+arRoOm9/MpGt4n6xn9fLnPFRSoLD0WFYGFUxQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3592,46 +3599,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/bgub/eta?sponsor=1"
-			}
-		},
-		"node_modules/execa": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-			"integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cross-spawn": "^7.0.3",
-				"get-stream": "^8.0.1",
-				"human-signals": "^5.0.0",
-				"is-stream": "^3.0.0",
-				"merge-stream": "^2.0.0",
-				"npm-run-path": "^5.1.0",
-				"onetime": "^6.0.0",
-				"signal-exit": "^4.1.0",
-				"strip-final-newline": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=16.17"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/execa?sponsor=1"
-			}
-		},
-		"node_modules/execa/node_modules/onetime": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-			"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mimic-fn": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/exsolve": {
@@ -3708,6 +3675,33 @@
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/fast-string-truncated-width": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+			"integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fast-string-width": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+			"integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-string-truncated-width": "^3.0.2"
+			}
+		},
+		"node_modules/fast-wrap-ansi": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+			"integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-string-width": "^3.0.2"
+			}
 		},
 		"node_modules/fastest-levenshtein": {
 			"version": "1.0.16",
@@ -3821,6 +3815,7 @@
 			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
 			"integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"is-callable": "^1.2.7"
 			},
@@ -3853,6 +3848,7 @@
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
 			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
@@ -3867,13 +3863,15 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true,
-			"license": "ISC"
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -3883,6 +3881,7 @@
 			"resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
 			"integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -3892,14 +3891,15 @@
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"license": "ISC",
+			"peer": true,
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
 			}
 		},
 		"node_modules/get-east-asian-width": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-			"integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3914,6 +3914,7 @@
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
 			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
 				"es-define-property": "^1.0.1",
@@ -3948,25 +3949,13 @@
 			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
 			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"dunder-proto": "^1.0.1",
 				"es-object-atoms": "^1.0.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/get-stream": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-			"integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/get-tsconfig": {
@@ -3983,14 +3972,14 @@
 			}
 		},
 		"node_modules/get-uri": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
-			"integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-7.0.0.tgz",
+			"integrity": "sha512-ZsC7KQxm1Hra8yO0RvMZ4lGJT7vnBtSNpEHKq39MPN7vjuvCiu1aQ8rkXUaIXG1y/TSDez97Gmv04ibnYqCp/A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"basic-ftp": "^5.0.2",
-				"data-uri-to-buffer": "^6.0.2",
+				"data-uri-to-buffer": "7.0.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -4128,6 +4117,7 @@
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
 			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -4140,7 +4130,8 @@
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/handlebars": {
 			"version": "4.7.8",
@@ -4179,6 +4170,7 @@
 			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
 			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"es-define-property": "^1.0.0"
 			},
@@ -4191,6 +4183,7 @@
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
 			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -4203,6 +4196,7 @@
 			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
 			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"has-symbols": "^1.0.3"
 			},
@@ -4218,6 +4212,7 @@
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
 			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"function-bind": "^1.1.2"
 			},
@@ -4226,13 +4221,13 @@
 			}
 		},
 		"node_modules/http-proxy-agent": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-8.0.0.tgz",
+			"integrity": "sha512-7pose0uGgrCJeH2Qh4JcNhWZp3u/oNrWjNYDK4ydOLxOpTw8V8ogHFAmkz0VWq96JBFj4umVJpvmQi287rSYLg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"agent-base": "^7.1.0",
+				"agent-base": "8.0.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -4240,33 +4235,23 @@
 			}
 		},
 		"node_modules/https-proxy-agent": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-8.0.0.tgz",
+			"integrity": "sha512-YYeW+iCnAS3xhvj2dvVoWgsbca3RfQy/IlaNHHOtDmU0jMqPI9euIq3Y9BJETdxk16h9NHHCKqp/KB9nIMStCQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"agent-base": "^7.1.2",
-				"debug": "4"
+				"agent-base": "8.0.0",
+				"debug": "^4.3.4"
 			},
 			"engines": {
 				"node": ">= 14"
 			}
 		},
-		"node_modules/human-signals": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-			"integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=16.17.0"
-			}
-		},
 		"node_modules/iconv-lite": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+			"integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4344,6 +4329,7 @@
 			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -4353,39 +4339,13 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"license": "ISC"
-		},
-		"node_modules/inquirer": {
-			"version": "12.11.1",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.11.1.tgz",
-			"integrity": "sha512-9VF7mrY+3OmsAfjH3yKz/pLbJ5z22E23hENKw3/LNSaA/sAt3v49bDRY+Ygct1xwuKT+U+cBfTzjCPySna69Qw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@inquirer/ansi": "^1.0.2",
-				"@inquirer/core": "^10.3.2",
-				"@inquirer/prompts": "^7.10.1",
-				"@inquirer/type": "^3.0.10",
-				"mute-stream": "^2.0.0",
-				"run-async": "^4.0.6",
-				"rxjs": "^7.8.2"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"@types/node": ">=18"
-			},
-			"peerDependenciesMeta": {
-				"@types/node": {
-					"optional": true
-				}
-			}
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/ip-address": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-			"integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+			"version": "10.7.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+			"integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4397,6 +4357,7 @@
 			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
 			"integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"has-tostringtag": "^1.0.2"
@@ -4412,7 +4373,8 @@
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/is-bun-module": {
 			"version": "2.0.0",
@@ -4429,6 +4391,7 @@
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
 			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -4476,6 +4439,7 @@
 			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
 			"integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.4",
 				"generator-function": "^2.0.0",
@@ -4501,6 +4465,19 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-in-ssh": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+			"integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-inside-container": {
@@ -4556,6 +4533,7 @@
 			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
 			"integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3"
@@ -4583,6 +4561,7 @@
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -4592,6 +4571,7 @@
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
 			"integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"gopd": "^1.2.0",
@@ -4615,24 +4595,12 @@
 				"protocols": "^2.0.1"
 			}
 		},
-		"node_modules/is-stream": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-			"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/is-typed-array": {
 			"version": "1.1.15",
 			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
 			"integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"which-typed-array": "^1.1.16"
 			},
@@ -4740,7 +4708,6 @@
 			"integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
 			}
@@ -4750,6 +4717,7 @@
 			"resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
 			"integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">= 0.6.0"
 			}
@@ -4758,13 +4726,24 @@
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
 			"integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ==",
-			"license": "BSD-3-Clause"
+			"license": "BSD-3-Clause",
+			"peer": true
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+			"integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -4799,6 +4778,7 @@
 			"resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.13.1.tgz",
 			"integrity": "sha512-WJeiE0jGfxYmtLwBTEk8+y/mYcaleyLXWaqp5bJu0/ZTSeG0KQq/wWQ8pmnkKenEdN6pdnn6QtcoSUkbqDHWNw==",
 			"license": "ISC",
+			"peer": true,
 			"bin": {
 				"jsonrepair": "bin/cli.js"
 			}
@@ -4808,6 +4788,7 @@
 			"resolved": "https://registry.npmjs.org/jssha/-/jssha-3.3.1.tgz",
 			"integrity": "sha512-VCMZj12FCFMQYcFLPRm/0lOBbLi8uM2BhXPTqw3U4YAfs4AZfiApOoBLoN8cQE60Z50m1MYMTQVCfgF/KaCVhQ==",
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"engines": {
 				"node": "*"
 			}
@@ -4879,7 +4860,8 @@
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/lodash.capitalize": {
 			"version": "4.2.1",
@@ -4965,14 +4947,15 @@
 			"resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
 			"integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
 		},
 		"node_modules/macos-release": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-3.4.0.tgz",
-			"integrity": "sha512-wpGPwyg/xrSp4H4Db4xYSeAr6+cFQGHfspHzDUdYxswDnUW0L5Ov63UuJiSr8NMSpyaChO4u1n0MXUvVPtrN6A==",
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-3.5.1.tgz",
+			"integrity": "sha512-Lci/1in+elqZ589PXnfP/iwZXpwQifTM94WJRQwG2tZSdfY7NfB/aUaTARHrohWCgHlXoabeaeXRDOnF5X9JQw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4987,6 +4970,7 @@
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
 			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -4996,18 +4980,12 @@
 			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
 			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"dependencies": {
 				"charenc": "0.0.2",
 				"crypt": "0.0.2",
 				"is-buffer": "~1.1.6"
 			}
-		},
-		"node_modules/merge-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
@@ -5038,6 +5016,7 @@
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
 			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -5047,24 +5026,12 @@
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
 			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"mime-db": "1.52.0"
 			},
 			"engines": {
 				"node": ">= 0.6"
-			}
-		},
-		"node_modules/mimic-fn": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-			"integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/mimic-function": {
@@ -5124,13 +5091,13 @@
 			"license": "MIT"
 		},
 		"node_modules/mute-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-			"integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+			"integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/n8n-workflow": {
@@ -5191,9 +5158,9 @@
 			"license": "MIT"
 		},
 		"node_modules/netmask": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-			"integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+			"integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5247,35 +5214,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/npm-run-path": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-			"integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"path-key": "^4.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/npm-run-path/node_modules/path-key": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/nypm": {
 			"version": "0.6.4",
 			"resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.4.tgz",
@@ -5306,6 +5244,7 @@
 			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
 			"integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.7",
 				"define-properties": "^1.2.1"
@@ -5322,6 +5261,7 @@
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
 			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -5331,6 +5271,7 @@
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
 			"integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.8",
 				"call-bound": "^1.0.3",
@@ -5359,6 +5300,7 @@
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"wrappy": "1"
 			}
@@ -5380,19 +5322,21 @@
 			}
 		},
 		"node_modules/open": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
-			"integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+			"integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"default-browser": "^5.2.1",
+				"default-browser": "^5.4.0",
 				"define-lazy-prop": "^3.0.0",
+				"is-in-ssh": "^1.0.0",
 				"is-inside-container": "^1.0.0",
-				"wsl-utils": "^0.1.0"
+				"powershell-utils": "^0.1.0",
+				"wsl-utils": "^0.3.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -5417,9 +5361,9 @@
 			}
 		},
 		"node_modules/ora": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-9.0.0.tgz",
-			"integrity": "sha512-m0pg2zscbYgWbqRR6ABga5c3sZdEon7bSgjnlXC64kxtxLOyjRcbbUkLj7HFyy/FTD+P2xdBWu8snGhYI0jc4A==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
+			"integrity": "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5429,9 +5373,8 @@
 				"is-interactive": "^2.0.0",
 				"is-unicode-supported": "^2.1.0",
 				"log-symbols": "^7.0.1",
-				"stdin-discarder": "^0.2.2",
-				"string-width": "^8.1.0",
-				"strip-ansi": "^7.1.2"
+				"stdin-discarder": "^0.3.1",
+				"string-width": "^8.1.0"
 			},
 			"engines": {
 				"node": ">=20"
@@ -5467,14 +5410,14 @@
 			}
 		},
 		"node_modules/ora/node_modules/string-width": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
-			"integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+			"integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"get-east-asian-width": "^1.3.0",
-				"strip-ansi": "^7.1.0"
+				"get-east-asian-width": "^1.5.0",
+				"strip-ansi": "^7.1.2"
 			},
 			"engines": {
 				"node": ">=20"
@@ -5484,17 +5427,17 @@
 			}
 		},
 		"node_modules/os-name": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/os-name/-/os-name-6.1.0.tgz",
-			"integrity": "sha512-zBd1G8HkewNd2A8oQ8c6BN/f/c9EId7rSUueOLGu28govmUctXmM+3765GwsByv9nYUdrLqHphXlYIc86saYsg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/os-name/-/os-name-7.0.0.tgz",
+			"integrity": "sha512-/HfRU/lPPr4T2VigM+cvM3cU77es+XF4OEAa4aE5zpdvrxHGD2NmH0AFIWpMNAb+CsZL45rlcIO49Re0ZcRseg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"macos-release": "^3.3.0",
-				"windows-release": "^6.1.0"
+				"macos-release": "^3.4.0",
+				"windows-release": "^7.1.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -5533,37 +5476,40 @@
 			}
 		},
 		"node_modules/pac-proxy-agent": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
-			"integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-8.0.0.tgz",
+			"integrity": "sha512-HyCoVbyQ/nbVlQ/R6wBu0YXhbG2oAnEK5BQ3xMyj1OffQmU5NoOnpLzgPlKHaobUzz5NK0+AZHby4TdydAEBUA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@tootallnate/quickjs-emscripten": "^0.23.0",
-				"agent-base": "^7.1.2",
+				"agent-base": "8.0.0",
 				"debug": "^4.3.4",
-				"get-uri": "^6.0.1",
-				"http-proxy-agent": "^7.0.0",
-				"https-proxy-agent": "^7.0.6",
-				"pac-resolver": "^7.0.1",
-				"socks-proxy-agent": "^8.0.5"
+				"get-uri": "7.0.0",
+				"http-proxy-agent": "8.0.0",
+				"https-proxy-agent": "8.0.0",
+				"pac-resolver": "8.0.0",
+				"quickjs-wasi": "^0.0.1",
+				"socks-proxy-agent": "9.0.0"
 			},
 			"engines": {
 				"node": ">= 14"
 			}
 		},
 		"node_modules/pac-resolver": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
-			"integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-8.0.0.tgz",
+			"integrity": "sha512-SVNzOxVq2zuTew3WAt7U8UghwzJzuWYuJryd3y8FxyLTZdjVoCzY8kLP39PpEqQCDvlMWdQXwViu0sYT3eiU2w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"degenerator": "^5.0.0",
+				"degenerator": "6.0.0",
 				"netmask": "^2.0.2"
 			},
 			"engines": {
 				"node": ">= 14"
+			},
+			"peerDependencies": {
+				"quickjs-wasi": "^0.0.1"
 			}
 		},
 		"node_modules/package-json-from-dist": {
@@ -5644,6 +5590,7 @@
 			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -5756,8 +5703,22 @@
 			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
 			"integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/powershell-utils": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+			"integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/prelude-ls": {
@@ -5771,9 +5732,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -5808,20 +5769,20 @@
 			"license": "MIT"
 		},
 		"node_modules/proxy-agent": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
-			"integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-7.0.0.tgz",
+			"integrity": "sha512-okTgt79rHTvMHkr/Ney5rZpgCHh3g1g3tI5uhkgN5b7OeI3n0Q/ui1uv9OdrnZNJM9WIZJqZPh/UJs+YtO/TMQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"agent-base": "^7.1.2",
+				"agent-base": "8.0.0",
 				"debug": "^4.3.4",
-				"http-proxy-agent": "^7.0.1",
-				"https-proxy-agent": "^7.0.6",
+				"http-proxy-agent": "8.0.0",
+				"https-proxy-agent": "8.0.0",
 				"lru-cache": "^7.14.1",
-				"pac-proxy-agent": "^7.1.0",
+				"pac-proxy-agent": "8.0.0",
 				"proxy-from-env": "^1.1.0",
-				"socks-proxy-agent": "^8.0.5"
+				"socks-proxy-agent": "9.0.0"
 			},
 			"engines": {
 				"node": ">= 14"
@@ -5865,6 +5826,13 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/quickjs-wasi": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-0.0.1.tgz",
+			"integrity": "sha512-fBWNLTBkxkLAhe1AzF1hyXEvuA+N+vV1WMP2D6iiMUblvmOt8Pp5t8zUcgvz7aYA1ldUdxDlgUse15dmcKjkNg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/rc9": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
@@ -5895,6 +5863,7 @@
 			"resolved": "https://registry.npmjs.org/recast/-/recast-0.22.0.tgz",
 			"integrity": "sha512-5AAx+mujtXijsEavc5lWXBPQqrM4+Dl5qNH96N2aNeuJFUzpiiToKPsxQD/zAIJHspz7zz0maX0PCtCTFVlixQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"assert": "^2.0.0",
 				"ast-types": "0.15.2",
@@ -5911,6 +5880,7 @@
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.15.2.tgz",
 			"integrity": "sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.0.1"
 			},
@@ -5919,9 +5889,9 @@
 			}
 		},
 		"node_modules/release-it": {
-			"version": "19.2.4",
-			"resolved": "https://registry.npmjs.org/release-it/-/release-it-19.2.4.tgz",
-			"integrity": "sha512-BwaJwQYUIIAKuDYvpqQTSoy0U7zIy6cHyEjih/aNaFICphGahia4cjDANuFXb7gVZ51hIK9W0io6fjNQWXqICg==",
+			"version": "20.2.0",
+			"resolved": "https://registry.npmjs.org/release-it/-/release-it-20.2.0.tgz",
+			"integrity": "sha512-9ZTk9ripgctC6VTqH+P54KuboK29A5mG/I3tFfS5hnoAnkwtFFAMHRidYz93ylrW995vF50Ny1aOGJiyRmEN7w==",
 			"dev": true,
 			"funding": [
 				{
@@ -5935,35 +5905,35 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@nodeutils/defaults-deep": "1.1.0",
+				"@inquirer/prompts": "8.4.2",
 				"@octokit/rest": "22.0.1",
 				"@phun-ky/typeof": "2.0.3",
 				"async-retry": "1.3.3",
 				"c12": "3.3.3",
-				"ci-info": "^4.3.1",
-				"eta": "4.5.0",
+				"ci-info": "^4.4.0",
+				"defu": "^6.1.7",
+				"eta": "4.5.1",
 				"git-url-parse": "16.1.0",
-				"inquirer": "12.11.1",
 				"issue-parser": "7.0.1",
 				"lodash.merge": "4.6.2",
 				"mime-types": "3.0.2",
 				"new-github-release-url": "2.0.0",
-				"open": "10.2.0",
-				"ora": "9.0.0",
-				"os-name": "6.1.0",
-				"proxy-agent": "6.5.0",
-				"semver": "7.7.3",
+				"open": "11.0.0",
+				"ora": "9.3.0",
+				"os-name": "7.0.0",
+				"proxy-agent": "7.0.0",
+				"semver": "7.7.4",
 				"tinyglobby": "0.2.15",
-				"undici": "6.23.0",
+				"undici": "7.24.5",
 				"url-join": "5.0.0",
 				"wildcard-match": "5.1.4",
-				"yargs-parser": "21.1.1"
+				"yargs-parser": "22.0.0"
 			},
 			"bin": {
 				"release-it": "bin/release-it.js"
 			},
 			"engines": {
-				"node": "^20.12.0 || >=22.0.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24.0.0"
 			}
 		},
 		"node_modules/release-it/node_modules/mime-db": {
@@ -5993,11 +5963,22 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
+		"node_modules/release-it/node_modules/yargs-parser": {
+			"version": "22.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+			"integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
+			}
+		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -6093,16 +6074,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/run-async": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
-			"integrity": "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.12.0"
-			}
-		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6127,21 +6098,12 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
-		"node_modules/rxjs": {
-			"version": "7.8.2",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-			"integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.1.0"
-			}
-		},
 		"node_modules/safe-regex-test": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
 			"integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"es-errors": "^1.3.0",
@@ -6166,14 +6128,15 @@
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
 			"integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
 			"license": "BlueOak-1.0.0",
+			"peer": true,
 			"engines": {
 				"node": ">=11.0.0"
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -6200,6 +6163,7 @@
 			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
 			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"define-data-property": "^1.1.4",
 				"es-errors": "^1.3.0",
@@ -6277,13 +6241,13 @@
 			}
 		},
 		"node_modules/socks": {
-			"version": "2.8.7",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-			"integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+			"version": "2.8.10",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.10.tgz",
+			"integrity": "sha512-e0VyvkVTwVYViNovRkZ9aodhxVlyoMn7eJhVUPxZ+eK9P/7CBkxvvsBOHqFPEH416726W8tLXXXjKwqgTErrCQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ip-address": "^10.0.1",
+				"ip-address": "^10.1.1",
 				"smart-buffer": "^4.2.0"
 			},
 			"engines": {
@@ -6292,13 +6256,13 @@
 			}
 		},
 		"node_modules/socks-proxy-agent": {
-			"version": "8.0.5",
-			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-			"integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-9.0.0.tgz",
+			"integrity": "sha512-fFlbMlfsXhK02ZB8aZY7Hwxh/IHBV9b1Oq9bvBk6tkFWXvdAxUgA0wbw/NYR5liU3Y5+KI6U4FH3kYJt9QYv0w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"agent-base": "^7.1.2",
+				"agent-base": "8.0.0",
 				"debug": "^4.3.4",
 				"socks": "^2.8.3"
 			},
@@ -6326,9 +6290,9 @@
 			}
 		},
 		"node_modules/stdin-discarder": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
-			"integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+			"integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -6452,19 +6416,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/strip-final-newline": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-			"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/strip-json-comments": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -6499,7 +6450,8 @@
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/tinyexec": {
 			"version": "1.0.2",
@@ -6552,7 +6504,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -6587,6 +6538,7 @@
 			"resolved": "https://registry.npmjs.org/transliteration/-/transliteration-2.3.5.tgz",
 			"integrity": "sha512-HAGI4Lq4Q9dZ3Utu2phaWgtm3vB6PkLUFqWAScg/UW+1eZ/Tg6Exo4oC0/3VUol/w4BlefLhUUSVBr/9/ZGQOw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"yargs": "^17.5.1"
 			},
@@ -6655,9 +6607,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.9.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -6707,13 +6659,13 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-			"integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
+			"integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=18.17"
+				"node": ">=20.18.1"
 			}
 		},
 		"node_modules/undici-types": {
@@ -6800,6 +6752,7 @@
 			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
 			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"is-arguments": "^1.0.4",
@@ -6829,6 +6782,7 @@
 			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
 			"integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"available-typed-arrays": "^1.0.7",
 				"call-bind": "^1.0.8",
@@ -6866,16 +6820,29 @@
 			"license": "ISC"
 		},
 		"node_modules/windows-release": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/windows-release/-/windows-release-6.1.0.tgz",
-			"integrity": "sha512-1lOb3qdzw6OFmOzoY0nauhLG72TpWtb5qgYPiSh/62rjc1XidBSDio2qw0pwHh17VINF217ebIkZJdFLZFn9SA==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/windows-release/-/windows-release-7.1.1.tgz",
+			"integrity": "sha512-0GBwC9WmR8Bm3WYiz3FC391054BsFHZ2gzBVdYj9uj5eIVYzbn/YPYCYW9SWdh9vwnLuzpn1UGwJKiMG4F236w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"execa": "^8.0.1"
+				"powershell-utils": "^0.2.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/windows-release/node_modules/powershell-utils": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.1.tgz",
+			"integrity": "sha512-C+y9x90UElAddDZmV4qOx9W53B61PO7cIqWz2dQsWlwswuq4mr8NEwytdGKboYbQlGZ3awrkTeNvcZiZNHnQ8A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -6983,28 +6950,30 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true,
-			"license": "ISC"
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/wsl-utils": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
-			"integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+			"integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"is-wsl": "^3.1.0"
+				"is-wsl": "^3.1.0",
+				"powershell-utils": "^0.1.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/wsl-utils/node_modules/is-wsl": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-			"integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+			"integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7022,6 +6991,7 @@
 			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
 			"integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"sax": ">=0.6.0",
 				"xmlbuilder": "~11.0.0"
@@ -7035,6 +7005,7 @@
 			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
 			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -7044,6 +7015,7 @@
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
 			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
 			"license": "ISC",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -7053,6 +7025,7 @@
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
 			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cliui": "^8.0.1",
 				"escalade": "^3.1.1",
@@ -7071,6 +7044,7 @@
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
 			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
 			"license": "ISC",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -7089,22 +7063,9 @@
 			}
 		},
 		"node_modules/yoctocolors": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-			"integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/yoctocolors-cjs": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
-			"integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+			"integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -7119,6 +7080,7 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
 			"integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jyln/n8n-nodes-ntfy",
-	"version": "2.0.0",
+	"version": "2.0.2",
 	"description": "A community n8n node for ntfy.sh",
 	"license": "MIT",
 	"homepage": "https://github.com/JYLN/n8n-nodes-ntfy.git",
@@ -45,10 +45,10 @@
 	"devDependencies": {
 		"@n8n/node-cli": "*",
 		"@types/node": "^25.0.10",
-		"eslint": "9.32.0",
-		"prettier": "3.6.2",
-		"release-it": "^19.0.4",
-		"typescript": "5.9.2"
+		"eslint": "9.39.4",
+		"prettier": "3.8.3",
+		"release-it": "20.2.0",
+		"typescript": "5.9.3"
 	},
 	"peerDependencies": {
 		"n8n-workflow": "*"


### PR DESCRIPTION
Due to my ignorance of HTTP Headers, the previous update disallowed any non-ASCII characters in the `Title` of the notification, causing rendering issues on ntfy. As well, if a file attachment (not URL attachment) was used in the notification, the message would be placed into a header, which means any rich-text/non-ASCII/markdown characters would either throw an error or not display properly.

This update includes an encoding method for headers, as well as general clean-up of the functions.

ntfy Docs regarding headers: https://docs.ntfy.sh/publish/#using-a-header

This update resolves #30 